### PR TITLE
Decomposition and normalisation

### DIFF
--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -288,6 +288,7 @@ julia> decompose(@optic _.a.b.c.d)
 
 julia> decompose((@optic _.c.d) ∘ (@optic _.a.b))
 ((@optic _.d), (@optic _.c), (@optic _.b), (@optic _.a))
+```
 """
 decompose(optic) = (optic,)
 decompose(optic::ComposedOptic) = (decompose(optic.outer)..., decompose(optic.inner)...)
@@ -330,6 +331,7 @@ julia> normalise(optic).inner
 
 julia> normalise(optic).outer
 (@optic _.c) ∘ (@optic _.b)
+```
 """
 normalise(optic) = optic
 normalise(optic::ComposedOptic) = foldl(∘, decompose(optic))

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -316,20 +316,20 @@ propname(::PropertyLens{name}) where {name} = name
 transforms the optic such that the `inner` lens contains always a the `PropertyLens`
 
 ```julia 
-julia> optic = (@optic _.a) ∘ (@optic _.b.c)
-(@optic _.a) ∘ (@optic _.c) ∘ (@optic _.b)
+julia> optic = (@optic _.c) ∘ (@optic _.a.b)
+(@optic _.c) ∘ (@optic _.b) ∘ (@optic _.a)
 
 julia> optic.inner
-(@optic _.c) ∘ (@optic _.b)
+(@optic _.b) ∘ (@optic _.a)
 
 julia> optic.outer
 (@optic _.a)
 
 julia> normalise(optic).inner
-(@optic _.b)
+(@optic _.a)
 
 julia> normalise(optic).outer
-(@optic _.a) ∘ (@optic _.c)
+(@optic _.c) ∘ (@optic _.b)
 """
 normalise(optic) = optic
 normalise(optic::ComposedOptic) = foldl(∘, decompose(optic))

--- a/test/test_optics.jl
+++ b/test/test_optics.jl
@@ -45,4 +45,18 @@ end
     @inferred modify(x -> 0, arr, @optic _ |> Elements() |> If(iseven))
 end
 
+@testset "Decomposition" begin 
+    @test Accessors.decompose(@optic _.a.b.c) == ((@optic _.c), (@optic _.b), (@optic _.a))
+end
+
+@testset "Propname" begin 
+    @test Accessors.propname(@optic _.a) == :a
+end
+
+@testset "Normalisation" begin 
+    @test Accessors.normalise((@optic _.c) ∘ (@optic _.a.b)).inner == @optic _.a
+    @test Accessors.normalise((@optic _.c) ∘ (@optic _.a.b)).outer.inner == @optic _.b
+    @test Accessors.normalise((@optic _.c) ∘ (@optic _.a.b)).outer.outer == @optic _.c
+end
+
 end#module


### PR DESCRIPTION
Hi,

these are implementations of those two functions we have discussed in the Setfield thread.
They works as
```
julia> optic = (@optic _.c) ∘ (@optic _.a.b)
(@optic _.c) ∘ (@optic _.b) ∘ (@optic _.a)

julia> optic.inner
(@optic _.b) ∘ (@optic _.a)

julia> optic.outer
(@optic _.a)

julia> normalise(optic).inner
(@optic _.a)

julia> normalise(optic).outer
(@optic _.c) ∘ (@optic _.b)
```

and
```
julia> decompose(@optic _.a.b.c.d)
((@optic _.d), (@optic _.c), (@optic _.b), (@optic _.a))
```

I have add docs and tests.