### PR TITLE
run doctests on julia 1.6.x

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ include("test_setindex.jl")
 include("test_functionlenses.jl")
 
 using Documenter: doctest
-if VERSION == v"1.6"
+if Base.thisminor(VERSION) == v"1.6"
     # ⨟ needs to be defined
     doctest(Accessors)
 else


### PR DESCRIPTION
I assume that was the actual intention - run on all 1.6 versions, not only 1.6.0.