### PR TITLE
support multiple indices into NamedTuples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Accessors"
 uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>", "Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/optics.jl
+++ b/src/optics.jl
@@ -429,9 +429,12 @@ function insert(obj::AbstractDict, l::IndexLens, val)
     res
 end
 
-@inline delete(obj::NamedTuple, l::IndexLens{Tuple{Symbol}}) = delete(obj, PropertyLens{only(l.indices)}())
-@inline delete(obj::NamedTuple, l::IndexLens{Tuple{Int}}) = delete(obj, PropertyLens{keys(obj)[only(l.indices)]}())
-@inline insert(obj::NamedTuple, l::IndexLens{Tuple{Symbol}}, val) = insert(obj, PropertyLens{only(l.indices)}(), val)
+@inline delete(obj::NamedTuple, l::IndexLens{Tuple{Symbol}}) = Base.structdiff(obj, NamedTuple{l.indices})
+@inline delete(obj::NamedTuple, l::IndexLens{<:Tuple{Tuple{Vararg{Symbol}}}}) = Base.structdiff(obj, NamedTuple{only(l.indices)})
+@inline delete(obj::NamedTuple, l::IndexLens{Tuple{Int}}) = Base.structdiff(obj, NamedTuple{(keys(obj)[only(l.indices)],)})
+@inline delete(obj::NamedTuple, l::IndexLens{<:Tuple{Tuple{Vararg{Int}}}}) = Base.structdiff(obj, NamedTuple{map(i -> keys(obj)[i], only(l.indices))})
+@inline insert(obj::NamedTuple, l::IndexLens{Tuple{Symbol}}, val) = merge(obj, NamedTuple{l.indices}((val,)))
+@inline insert(obj::NamedTuple, l::IndexLens{<:Tuple{Tuple{Vararg{Symbol}}}}, vals) = merge(obj, NamedTuple{only(l.indices)}(vals))
 
 struct DynamicIndexLens{F}
     f::F

--- a/src/setindex.jl
+++ b/src/setindex.jl
@@ -27,3 +27,5 @@ end
 
 # copied from Base: this method doesn't exist in Julia 1.3
 @inline setindex(nt::NamedTuple, v, idx::Symbol) = merge(nt, (; idx => v))
+
+@inline setindex(nt::NamedTuple, v, idx::Tuple{Vararg{Symbol}}) = merge(nt, NamedTuple{idx}(v))

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -214,6 +214,13 @@ end
     l = @optic _[1:3]
     @test l isa Accessors.IndexLens
     @test l([4,5,6,7]) == [4,5,6]
+
+    nt = (a=1, b=2, c=3)
+    l = @optic _[(:a, :c)]
+    @test l isa Accessors.IndexLens
+    VERSION >= v"1.7" && @test l(nt) === (a=1, c=3)
+    @test set(nt, l, ('1', '2')) === (a='1', b=2, c='2')
+    @test set(nt, l, (c='2', a='1')) === (a='1', b=2, c='2')
 end
 
 @testset "DynamicIndexLens" begin

--- a/test/test_delete.jl
+++ b/test/test_delete.jl
@@ -31,9 +31,12 @@ using StaticArrays
 
     @testset "macro" begin
         x = (a=1, b=2, c=3)
-        @test @delete(x.c) == (a=1, b=2)
+        @test @delete(x.c) === (a=1, b=2)
+        @test @delete(x[(:a, :c)]) === (b=2,)
+        @test @delete(x[(2, 3)]) === (a=1,)
         x = (a=1, b=(c=2, d=3))
-        @test @delete(x.b.c) == (a=1, b=(d=3,))
+        @test @delete(x.b.c) === (a=1, b=(d=3,))
+        @test @delete(x.b[(:c,)]) === (a=1, b=(d=3,))
         x = [1, 2, 3]
         @test @delete(x[2]) == [1, 3]
         @test_throws BoundsError @delete(x[10])

--- a/test/test_insert.jl
+++ b/test/test_insert.jl
@@ -28,23 +28,27 @@ using Accessors: insert
             @inferred insert((a=1, b=(2, 3)), @optic(_.b[2]), "xxx")
             true
         end
+    end
+
+    @testset "macro" begin
+        x = (b=2, c=3)
+        @test @insert(x.a = 1) === (b=2, c=3, a=1)
+        @test @insert(x[(:a, :x)] = (1, :xyz)) === (b=2, c=3, a=1, x=:xyz)
+        @test @insert(x[(:a, :x)] = (x=:xyz, a=1)) === (b=2, c=3, a=1, x=:xyz)
+        x = [1, 2]
+        @test @insert(x[3] = 3) == [1, 2, 3]
+        x = (a=(b=(1, 2),), c=1)
+        @test @insert(x.a.b[1] = 0) == (a=(b=(0, 1, 2),), c=1)
 
         # inferred & constant-propagated:
         function doit(nt)
             nt = @delete nt[1]
             nt = @insert nt[:a] =1
+            nt = @delete nt[(:a, :c)]
+            nt = @insert nt[(:x, :y)] = ("def", :abc)
             return nt
         end
-        @test @inferred(doit((a='3', b=2, c="1"))) === (b=2, c="1", a=1)
-    end
-
-    @testset "macro" begin
-        x = (b=2, c=3)
-        @test @insert(x.a = 1) == (b=2, c=3, a=1)
-        x = [1, 2]
-        @test @insert(x[3] = 3) == [1, 2, 3]
-        x = (a=(b=(1, 2),), c=1)
-        @test @insert(x.a.b[1] = 0) == (a=(b=(0, 1, 2),), c=1)
+        @test @inferred(doit((a='3', b=2, c="1"))) === (b=2, x="def", y=:abc)
     end
 end
 


### PR DESCRIPTION
following new (julia 1.7) indexing behavior of `(a=1, b=2, c=3)[(:a, :b)] == (a=1, b=2)`