### PR TITLE
support two-argument functions in optics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Accessors"
 uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>", "Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/functionlenses.jl
+++ b/src/functionlenses.jl
@@ -7,6 +7,8 @@ delete(obj, ::typeof(first)) = delete(obj, IndexLens((firstindex(obj),)))
 insert(obj, ::typeof(last), val) = insert(obj, IndexLens((lastindex(obj) + 1,)), val)
 insert(obj, ::typeof(first), val) = insert(obj, IndexLens((firstindex(obj),)), val)
 
+delete(obj, o::Base.Fix2{typeof(first)}) = obj[(firstindex(obj) + o.x):end]
+
 set(obj, ::typeof(identity), val) = val
 set(obj, ::typeof(inv), new_inv) = inv(new_inv)
 

--- a/test/test_delete.jl
+++ b/test/test_delete.jl
@@ -12,6 +12,11 @@ using StaticArrays
         @test delete( (1,2,3), last ) == (1, 2)
         @test @inferred(delete( (a=1, b=2, c=3), first ))== (b=2, c=3)
         @test @inferred(delete( SVector(1,2,3), last )) === SVector(1, 2)
+
+        l = @optic first(_, 2)
+        VERSION >= v"1.4" && @test l((1,2,3)) == [1,2]
+        @test delete((1,2,3), l) === (3,)
+
         let A = [1,2,3]
             @test delete(A, @optic(_[2])) == [1, 3]
             @test_throws Exception delete(A, @optic(_[2, 2]))

--- a/test/test_functionlenses.jl
+++ b/test/test_functionlenses.jl
@@ -94,4 +94,20 @@ end
 
 end
 
+@testset "custom binary function" begin
+    ↑(x, y) = x - y
+    Accessors.set(x, f::Base.Fix1{typeof(↑)}, y) = f.x - y
+    Accessors.set(x, f::Base.Fix2{typeof(↑)}, y) = f.x + y
+
+    x = 5
+    o1 = @optic 2 ↑ _
+    o2 = @optic _ ↑ 2
+    @test o1(x) == -3
+    @test set(x, o1, 10) == -8
+    @test o2(x) == 3
+    @test set(x, o2, 10) == 12
+    test_getset_laws(o1, x, 2, -3)
+    test_getset_laws(o2, x, 2, -3)
+end
+
 end # module


### PR DESCRIPTION
For now, contains implementation and a single specific `delete` method as an example.
If others agree this extension is a good idea, will add more methods and tests.