### PR TITLE
Document direct constructors, add convenience form.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Accessors"
 uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>", "Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "0.1.9"
+version = "0.1.10"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/docs/src/lenses.md
+++ b/docs/src/lenses.md
@@ -38,6 +38,9 @@ julia> v = (a = 1:3, )
 julia> l = opcompose(PropertyLens(:a), IndexLens(1))
 (@optic _[1]) ∘ (@optic _.a)
 
+julia> l ≡ @optic _.a[1]   # equivalent to macro form
+true
+
 julia> l(v)
 1
 

--- a/docs/src/lenses.md
+++ b/docs/src/lenses.md
@@ -3,6 +3,7 @@
 Accessors.jl is build around so called lenses. A Lens allows to access or replace deeply nested parts of complicated objects.
 
 # Example
+
 ```jldoctest
 julia> using Accessors
 
@@ -24,6 +25,24 @@ T("AA", "BB")
 
 julia> modify(lowercase, obj, lens)
 T("aa", "BB")
+```
+
+Lenses can also be constructed directly and composed with [`opcompose`](@ref), `⨟`, or `∘` (note reverse order).
+
+```jldoctest
+julia> using Accessors
+
+julia> v = (a = 1:3, )
+(a = 1:3,)
+
+julia> l = opcompose(PropertyLens(:a), IndexLens(1))
+(@optic _[1]) ∘ (@optic _.a)
+
+julia> l(v)
+1
+
+julia> set(v, l, 3)
+(a = [3, 2, 3],)
 ```
 
 # Interface

--- a/src/optics.jl
+++ b/src/optics.jl
@@ -1,4 +1,5 @@
 export @optic
+export PropertyLens, IndexLens
 export set, modify, delete, insert
 export ∘, opcompose, var"⨟"
 export Elements, Recursive, If, Properties
@@ -129,7 +130,7 @@ innertype(::Type{ComposedOptic{Outer,Inner}}) where {Outer,Inner} = Inner
 # also better way to organize traits will
 # probably only emerge over time
 #
-# TODO 
+# TODO
 # There is an inference regression as of Julia v1.7.0
 # if recursion is combined with trait based dispatch
 # https://github.com/JuliaLang/julia/issues/43296
@@ -376,6 +377,16 @@ end
 ################################################################################
 struct PropertyLens{fieldname} end
 
+"""
+    PropertyLens{fieldname}()
+    PropertyLens(fieldname)
+
+Construct a lens for accessing a property `fieldname` of an object.
+
+The second constructor may not be type stable when `fieldname` is not a constant.
+"""
+@inline PropertyLens(fieldname) = PropertyLens{fieldname}()
+
 function (l::PropertyLens{field})(obj) where {field}
     getproperty(obj, field)
 end
@@ -396,6 +407,14 @@ end
 struct IndexLens{I<:Tuple}
     indices::I
 end
+
+"""
+    IndexLens(indices::Tuple)
+    IndexLens(indices::Integer...)
+
+Construct a lens for accessing an element of an object at `indices` via `[]`.
+"""
+IndexLens(indices::Integer...) = IndexLens(indices)
 
 Base.@propagate_inbounds function (lens::IndexLens)(obj)
     getindex(obj, lens.indices...)

--- a/test/test_optics.jl
+++ b/test/test_optics.jl
@@ -84,7 +84,7 @@ end
 
 @testset "convenience constructors" begin
     @test IndexLens(1, 2, 3) === IndexLens((1, 2, 3))
-    @test PropertyLens(:a) == PropertyLens{:a}()
+    @test PropertyLens(:a) === PropertyLens{:a}()
 end
 
 end#module

--- a/test/test_optics.jl
+++ b/test/test_optics.jl
@@ -83,7 +83,7 @@ end
 end
 
 @testset "convenience constructors" begin
-    @test IndexLens(1, 2, 3) == IndexLens((1, 2, 3))
+    @test IndexLens(1, 2, 3) === IndexLens((1, 2, 3))
     @test PropertyLens(:a) == PropertyLens{:a}()
 end
 

--- a/test/test_optics.jl
+++ b/test/test_optics.jl
@@ -82,4 +82,9 @@ end
     @inferred modify(x -> 0, arr, @optic _ |> Elements() |> If(iseven))
 end
 
+@testset "convenience constructors" begin
+    @test IndexLens(1, 2, 3) == IndexLens((1, 2, 3))
+    @test PropertyLens(:a) == PropertyLens{:a}()
+end
+
 end#module


### PR DESCRIPTION
- add convenience constructors for `IndexLens` and `PropertyLens`
- export and document both
- explain direct lens construction in the manual

Fixes #47.