### PR TITLE
add mapview() support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,9 +31,10 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 PerformanceTestTools = "dc46b164-d16f-48ec-a853-60448fc869fe"
 QuickTypes = "ae2dfa86-617c-530c-b392-ef20fdad97bb"
+SplitApplyCombine = "03a91e81-4c3e-53e1-a0a4-9c0c8f19dd66"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StaticNumbers = "c5e4b96a-f99f-5557-8ed2-dc63ef9b5131"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Documenter", "PerformanceTestTools", "QuickTypes", "StaticArrays", "BenchmarkTools", "InteractiveUtils", "StaticNumbers"]
+test = ["Test", "Documenter", "PerformanceTestTools", "QuickTypes", "SplitApplyCombine", "StaticArrays", "BenchmarkTools", "InteractiveUtils", "StaticNumbers"]

--- a/src/Accessors.jl
+++ b/src/Accessors.jl
@@ -16,6 +16,7 @@ end
 
 function __init__()
     @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" include("staticarrays.jl")
+    @require SplitApplyCombine = "03a91e81-4c3e-53e1-a0a4-9c0c8f19dd66" include("mapview.jl")
 end
 
 include("setindex.jl")

--- a/src/mapview.jl
+++ b/src/mapview.jl
@@ -1,0 +1,3 @@
+import .SplitApplyCombine: MappedArray
+
+Base.setindex!(ma::MappedArray, val, ix) = parent(ma)[ix] = set(parent(ma)[ix], ma.f, val)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,6 +13,7 @@ include("test_quicktypes.jl")
 include("test_setmacro.jl")
 include("test_setindex.jl")
 include("test_functionlenses.jl")
+include("test_mapview.jl")
 
 using Documenter: doctest
 if Base.thisminor(VERSION) == v"1.6"

--- a/test/test_mapview.jl
+++ b/test/test_mapview.jl
@@ -1,0 +1,14 @@
+module TestMapview
+using Test
+using Accessors
+using SplitApplyCombine
+
+@testset "mapview" begin
+    X = [(a=1, b=2), (a=3, b=4)]
+    Y = mapview(@optic(_.b), X)
+    @test Y == [2, 4]
+    Y[2] = 100
+    @test Y == [2, 100]
+    @test X == [(a=1, b=2), (a=3, b=100)]
+end
+end


### PR DESCRIPTION
I really like this feature, and how simple it was to implement!
Transparently set values on mapped array views (from `SplitApplyCombine.jl`) when the mapping function is an optic.
The simplest example from tests:
```julia
X = [(a=1, b=2), (a=3, b=4)]
Y = mapview(@optic(_.b), X)
@test Y == [2, 4]
Y[2] = 100
@test X == [(a=1, b=2), (a=3, b=100)]
```

Haven't noticed before that `Accessors.jl` already uses `Requires`, which makes this addition possible without extra dependencies.