### PR TITLE
Drop Requires, depend on StaticArraysCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,7 +23,7 @@ MacroTools = "0.4.4, 0.5"
 StaticArraysCore = "1"
 StaticNumbers = "0.3"
 Unitful = "1"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+StaticArraysCore = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
@@ -20,7 +20,7 @@ CompositionsBase = "0.1"
 ConstructionBase = "1.2"
 InverseFunctions = "0.1.5"
 MacroTools = "0.4.4, 0.5"
-Requires = "0.5, 1.0"
+StaticArraysCore = "1"
 StaticNumbers = "0.3"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ InverseFunctions = "0.1.5"
 MacroTools = "0.4.4, 0.5"
 StaticArraysCore = "1"
 StaticNumbers = "0.3"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/README.md
+++ b/README.md
@@ -7,10 +7,6 @@
 The goal of [Accessors.jl](https://github.com/JuliaObjects/Accessors.jl) is to make updating immutable data simple.
 It is the successor of [Setfield.jl](https://github.com/jw3126/Setfield.jl).
 
-## Warning
-
-Accessors.jl is currently in an experimental stage. We may introduce breaking changes without clear deprecation path. For a more stable package we recommend [Setfield.jl](https://github.com/jw3126/Setfield.jl).
-
 # Usage
 Updating immutable data was never easier:
 ```julia

--- a/src/Accessors.jl
+++ b/src/Accessors.jl
@@ -1,10 +1,7 @@
 module Accessors
 using MacroTools
 using MacroTools: isstructdef, splitstructdef, postwalk
-using Requires: @require
 using InverseFunctions
-
-
 
 if !isdefined(Base, :only)
     # Julia pre-1.4
@@ -12,10 +9,6 @@ if !isdefined(Base, :only)
         length(x) == 1 || throw(ArgumentError("Collection contains $(length(x)) elements, must contain exactly 1 element"))
         first(x)
     end
-end
-
-function __init__()
-    @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" include("staticarrays.jl")
 end
 
 include("setindex.jl")

--- a/src/Accessors.jl
+++ b/src/Accessors.jl
@@ -16,6 +16,7 @@ include("optics.jl")
 include("getsetall.jl")
 include("sugar.jl")
 include("functionlenses.jl")
+include("staticarrays.jl")
 include("testing.jl")
 
 end

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -1,5 +1,5 @@
 import StaticArraysCore
 
 @inline setindex(a::StaticArraysCore.StaticArray, args...) = Base.setindex(a, args...)
-@inline delete(obj::StaticArraysCore.SVector, l::IndexLens) = StaticArrays.deleteat(obj, only(l.indices))
-@inline insert(obj::StaticArraysCore.SVector, l::IndexLens, val) = StaticArrays.insert(obj, only(l.indices), val)
+@inline delete(obj::StaticArraysCore.SVector, l::IndexLens) = StaticArraysCore.deleteat(obj, only(l.indices))
+@inline insert(obj::StaticArraysCore.SVector, l::IndexLens, val) = StaticArraysCore.insert(obj, only(l.indices), val)

--- a/src/staticarrays.jl
+++ b/src/staticarrays.jl
@@ -1,5 +1,5 @@
-import .StaticArrays
+import StaticArraysCore
 
-@inline setindex(a::StaticArrays.StaticArray, args...) = Base.setindex(a, args...)
-@inline delete(obj::StaticArrays.SVector, l::IndexLens) = StaticArrays.deleteat(obj, only(l.indices))
-@inline insert(obj::StaticArrays.SVector, l::IndexLens, val) = StaticArrays.insert(obj, only(l.indices), val)
+@inline setindex(a::StaticArraysCore.StaticArray, args...) = Base.setindex(a, args...)
+@inline delete(obj::StaticArraysCore.SVector, l::IndexLens) = StaticArrays.deleteat(obj, only(l.indices))
+@inline insert(obj::StaticArraysCore.SVector, l::IndexLens, val) = StaticArrays.insert(obj, only(l.indices), val)


### PR DESCRIPTION
Because of method invalidations, Requires.jl can cause package load times to be much longer. Accessors currently uses Requires for StaticArrays.jl, which is fairly heavy-weight. But that package has recently been refactored to add a StaticArraysCore.jl, which is very light.

This little PR drops use of Requires in favor of a dependency on StaticArraysCore.