### PR TITLE
simplify and generalize mapproperties()

### DIFF
--- a/src/optics.jl
+++ b/src/optics.jl
@@ -299,15 +299,9 @@ This function should not be overloaded directly. Instead both of
 should be overloaded.
 $EXPERIMENTAL
 """
-function mapproperties end
-
-function mapproperties(f, nt::NamedTuple)
-    map(f, nt)
-end
-
 function mapproperties(f, obj)
     nt = getproperties(obj)
-    patch = mapproperties(f, nt)
+    patch = map(f, nt)
     return setproperties(obj, patch)
 end
 

--- a/test/test_optics.jl
+++ b/test/test_optics.jl
@@ -9,6 +9,11 @@ import ConstructionBase
     res = @inferred mapproperties(x->2x, (a=1, b=2))
     @test res === (a=2, b=4)
     @test NamedTuple() === @inferred mapproperties(cos, NamedTuple())
+
+    res = @inferred mapproperties(x->2x, (1, 2))
+    @test res === (2, 4)
+    @test () === @inferred mapproperties(cos, ())
+
     struct S{A,B}
         a::A
         b::B
@@ -34,6 +39,10 @@ end
 @testset "Properties" begin
     pt = (x=1, y=2, z=3)
     @test (x=0, y=1, z=2) === @set pt |> Properties() -= 1
+    @inferred modify(x->x-1, pt, Properties())
+
+    pt = (1, 2, 3)
+    @test (0, 1, 2) === @set pt |> Properties() -= 1
     @inferred modify(x->x-1, pt, Properties())
 
     # custom struct


### PR DESCRIPTION
noticed that get/setproperties work for Tuples, but mapproperties doesn't