### PR TITLE
more compact show() representation

### DIFF
--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -394,10 +394,25 @@ function opticmacro(optictransform, ex)
 end
 
 
-_show(io::IO, optic::PropertyLens{field}) where {field} = print(io, "(@optic _.$field)")
-_show(io::IO, optic::IndexLens) = print(io, "(@optic _[", join(repr.(optic.indices), ", "), "])")
-Base.show(io::IO, optic::Union{IndexLens, PropertyLens}) = _show(io, optic)
-Base.show(io::IO, ::MIME"text/plain", optic::Union{IndexLens, PropertyLens}) = _show(io, optic)
+_shortstring(prev, o::PropertyLens{field}) where {field} = "$prev.$field"
+_shortstring(prev, o::IndexLens) ="$prev[$(join(repr.(o.indices), ", "))]"
+_shortstring(prev, o::Function) = "$o($prev)"
+_shortstring(prev, o::Base.Fix1) = "$(o.f)($(o.x), $prev)"
+_shortstring(prev, o::Base.Fix2) = "$(o.f)($prev, $(o.x))"
+Base.show(io::IO, optic::Union{IndexLens, PropertyLens}) = print(io, "(@optic $(_shortstring("_", optic)))")
+function Base.show(io::IO, optic::ComposedFunction{<:Any, <:Union{IndexLens, PropertyLens}})
+    opts = deopcompose(optic)
+    inner = Iterators.takewhile(x -> applicable(_shortstring, "", x), opts)
+    outer = Iterators.dropwhile(x -> applicable(_shortstring, "", x), opts)
+    if !isempty(outer)
+        show(io, opcompose(outer...))
+        print(io, " ∘ ")
+    end
+    print(io, "(@optic ", reduce(_shortstring, inner; init="_"), ")")
+end
+Base.show(io::IO, ::MIME"text/plain", optic::Union{IndexLens, PropertyLens}) = show(io, optic)
+Base.show(io::IO, ::MIME"text/plain", optic::ComposedFunction{<:Any, <:Union{IndexLens, PropertyLens}}) = show(io, optic)
+
 
 # debugging
 show_composition_order(optic) = (show_composition_order(stdout, optic); println())

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -481,6 +481,7 @@ else
                 @optic _ |> UserDefinedLens() |> _.b
                 (@optic _.a) ∘ UserDefinedLens()   ∘ (@optic _.b)
                 (@optic _.a) ∘ LensIfTextPlain() ∘ (@optic _.b)
+                @optic 2 * (abs(_.a.b[2].c) + 1)
             ]
             buf = IOBuffer()
             show(buf, item)


### PR DESCRIPTION
Even moderately complex optic aren't most readable with the current `show`:
```julia
julia> @optic last(_.a[1].b)
last ∘ (@optic _.b) ∘ (@optic _[1]) ∘ (@optic _.a)
```
This PR changes to:
```julia
julia> @optic last(_.a[1].b)
(@optic last(_.a[1].b))
```
No type piracy, and all string-reconstruction tests pass.