### PR TITLE
Add prefix to extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [extensions]
-StaticArraysExt = "StaticArrays"
+AccessorsStaticArraysExt = "StaticArrays"
 
 [compat]
 Compat = "3.18, 4"

--- a/ext/AccessorsStaticArraysExt.jl
+++ b/ext/AccessorsStaticArraysExt.jl
@@ -1,4 +1,4 @@
-module StaticArraysExt
+module AccessorsStaticArraysExt
 isdefined(Base, :get_extension) ? (import StaticArrays) : (import ..StaticArrays)
 using Accessors
 using Accessors: only  # for 1.3-

--- a/src/Accessors.jl
+++ b/src/Accessors.jl
@@ -17,7 +17,7 @@ if !isdefined(Base, :get_extension)
 end
 @static if !isdefined(Base, :get_extension)
     function __init__()
-        @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" include("../ext/StaticArraysExt.jl")
+        @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" include("../ext/AccessorsStaticArraysExt.jl")
     end
 end
 


### PR DESCRIPTION
Extensions with non-unique name cause collisions and hence break e.g. compilation of sysimages. This PR adds a prefix to the extension to work around that issue. See https://github.com/JuliaMath/ChangesOfVariables.jl/pull/13 for a longer discussion.