### PR TITLE
Show essentials of package in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ julia> nt
 (a = 1, b = 2)
 ```
 
-To overwrite the old definition, we can rebind `nt` to the mutated version:
+To overwrite the old definition, we can rebind `nt` to the new version:
 ```julia
 julia> nt = @set nt.b=3
 (a = 1, b = 3)

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ julia> @set nt.b=3
 (a = 1, b = 3)
 ```
 
-Note that this only returns a updated copy of `nt`, and *does not overwrite or mutate* the 
+Note that this only returns an updated copy of `nt`, and *does not overwrite or mutate* the 
 value bound to `nt`:
 ```julia
 julia> nt

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ julia> @set nt.b=3
 (a = 1, b = 3)
 ```
 
-Note that this only returns a mutated version of `nt`, and *does not overwrite* the 
+Note that this only returns a updated copy of `nt`, and *does not overwrite or mutate* the 
 value bound to `nt`:
 ```julia
 julia> nt

--- a/README.md
+++ b/README.md
@@ -8,12 +8,47 @@ The goal of [Accessors.jl](https://github.com/JuliaObjects/Accessors.jl) is to m
 It is the successor of [Setfield.jl](https://github.com/jw3126/Setfield.jl).
 
 # Usage
-Updating immutable data was never easier:
+Say you have some immutable data structure, such as a `NamedTuple`:
 ```julia
-using Accessors
-@set obj.a.b.c = d
+julia> nt = (a=1, b=2)
+(a = 1, b = 2)
+
 ```
-To get started, see [this tutorial](https://juliaobjects.github.io/Accessors.jl/stable/getting_started/) and/or watch this video:
+If you try something like `nt.b=3`, it will throw an error. But 
+using Accessors, we can change it anyways:
+```julia
+julia> using Accessors
+
+julia> @set nt.b=3
+(a = 1, b = 3)
+```
+
+Note that this only returns a mutated version of `nt`, and *does not overwrite* the 
+value bound to `nt`:
+```julia
+julia> nt
+(a = 1, b = 2)
+```
+
+To overwrite the old definition, we can rebind `nt` to the mutated version:
+```julia
+julia> nt = @set nt.b=3
+(a = 1, b = 3)
+
+julia> nt
+(a = 1, b = 3)
+```
+
+As this is a common use case, the convenience macro `@reset` overwrites what you are mutating:
+```julia
+julia> @reset nt.b=4
+(a = 1, b = 4)
+
+julia> nt
+(a = 1, b = 4)
+```
+
+For more detail, see [this tutorial](https://juliaobjects.github.io/Accessors.jl/stable/getting_started/) and/or watch this video:
 
 [![JuliaCon2020 Changing the immutable](https://img.youtube.com/vi/vkAOYeTpLg0/0.jpg)](https://youtu.be/vkAOYeTpLg0 "Changing the immutable")
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ julia> nt
 (a = 1, b = 3)
 ```
 
-As this is a common use case, the convenience macro `@reset` overwrites what you are mutating:
+As this is a common use case, the convenience macro `@reset` rebinds the variable (`nt`) to the updated version:
 ```julia
 julia> @reset nt.b=4
 (a = 1, b = 4)


### PR DESCRIPTION
This is because I was really expecting `@set` to overwrite the old variable, and so I have documented the part that confused me in the readme in a simple example.

I know this is spelled out in the docs, but I honestly expect to be able to use such a simple package by seing 2 lines of example code, and do not come to it with the mindset that it is neccessary to open docs. In case others are like me, this should make their lives easier.