### PR TITLE
fix setall(Tuple, Properties)

### DIFF
--- a/src/getsetall.jl
+++ b/src/getsetall.jl
@@ -65,6 +65,7 @@ function setall(obj, ::Properties, vs)
     names = propertynames(obj)
     setproperties(obj, NamedTuple{names}(NTuple{length(names)}(vs)))
 end
+setall(obj::Tuple, ::Properties, vs) = setproperties(obj, vs)
 setall(obj::NamedTuple{NS}, ::Elements, vs) where {NS} = NamedTuple{NS}(NTuple{length(NS)}(vs))
 setall(obj::NTuple{N, Any}, ::Elements, vs) where {N} = (@assert length(vs) == N; NTuple{N}(vs))
 setall(obj::AbstractArray, ::Elements, vs::AbstractArray) = (@assert length(obj) == length(vs); reshape(vs, size(obj)))

--- a/test/test_getsetall.jl
+++ b/test/test_getsetall.jl
@@ -77,6 +77,10 @@ end
         @test (a=2, b="3") === @inferred setall((a=1, b="2"), o, (2, "3"))
         @test (a=2, b=3) === @inferred setall((a=1, b="2"), o, [2, 3])
     end
+    for o in [Elements(), Properties()]
+        @test (2, 3) === @inferred setall((1, "2"), o, (2, 3))
+        @test (2, "3") === @inferred setall((1, "2"), o, (2, "3"))
+    end
     @test (2, 3) === @inferred setall((1, "2"), Elements(), (2, 3))
     @test (2, "3") === @inferred setall((1, "2"), Elements(), (2, "3"))
     @test (2, 3) === @inferred setall((1, "2"), Elements(), [2, 3])


### PR DESCRIPTION
Didn't work: cannot construct a NamedTuple out of Tuple properties, they don't have names.