### PR TITLE
"flipped" indexlens

### DIFF
--- a/src/functionlenses.jl
+++ b/src/functionlenses.jl
@@ -42,12 +42,6 @@ function set(obj::NamedTuple, ::Type{NamedTuple{KS}}, val::NamedTuple) where {KS
     setproperties(obj, NamedTuple{KS}(val))
 end
 
-function set(obj, f::Base.Fix1{typeof(getindex)}, val)
-    ix = findfirst(isequal(val), f.x)
-    ix === nothing && throw(ArgumentError("value $val not found in $(f.x)"))
-    return ix
-end
-
 ################################################################################
 ##### eltype
 ################################################################################

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -319,12 +319,9 @@ end
 end
 
 @testset "flipped index" begin
-    obj = (a=2, b=nothing)
-    lens = @optic (4:10)[_.a]
-    @test @inferred(set(obj, lens, 4)).a == 1
-    @test_throws ArgumentError set(obj, lens, 12)
-    test_getset_laws(lens, obj, 5, 6)
-    test_modify_law(x -> x + 1, lens, obj)
+    lut = 4:10
+    @test (@optic lut[_.a]) === Base.Fix1(getindex, lut) ∘ PropertyLens(:a)
+    # set() should be implemented in packages for their types
 end
 
 @testset "StaticNumbers" begin


### PR DESCRIPTION
Works with dictionaries as well, not only arrays. Pretty convenient:
```julia
julia> lut = dictionary([:a => 1, :b => 2, :c => 3])
julia> obj = (x=:a, y=2)
julia> o = @optic lut[_.x]

julia> o(obj)
1
julia> modify(x -> x + 1, obj, o)
(x = :b, y = 2)
```

Hope I don't overwhelm you with multiple PRs :) Each is pretty self-contained and independent, so a couple of smaller ones should be better than a single large.