### PR TITLE
Prefix parent package name to extension names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Accessors"
 uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>", "Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "0.1.29"
+version = "0.1.30"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/Project.toml
+++ b/Project.toml
@@ -22,10 +22,10 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 
 [extensions]
-AxisKeysExt = "AxisKeys"
-IntervalSetsExt = "IntervalSets"
-StaticArraysExt = "StaticArrays"
-StructArraysExt = "StructArrays"
+AccessorsAxisKeysExt = "AxisKeys"
+AccessorsIntervalSetsExt = "IntervalSets"
+AccessorsStaticArraysExt = "StaticArrays"
+AccessorsStructArraysExt = "StructArrays"
 
 [compat]
 AxisKeys = "0.1,0.2"  # extension tests only pass for AxisKeys 0.2, but 0.1 compat is required to run tests on Julia 1.3

--- a/ext/AccessorsAxisKeysExt.jl
+++ b/ext/AccessorsAxisKeysExt.jl
@@ -1,4 +1,4 @@
-module AxisKeysExt
+module AccessorsAxisKeysExt
 using Accessors
 using AxisKeys
 

--- a/ext/AccessorsIntervalSetsExt.jl
+++ b/ext/AccessorsIntervalSetsExt.jl
@@ -1,4 +1,4 @@
-module IntervalSetsExt
+module AccessorsIntervalSetsExt
 using Accessors
 using IntervalSets
 

--- a/ext/AccessorsStaticArraysExt.jl
+++ b/ext/AccessorsStaticArraysExt.jl
@@ -1,4 +1,4 @@
-module StaticArraysExt
+module AccessorsStaticArraysExt
 isdefined(Base, :get_extension) ? (import StaticArrays) : (import ..StaticArrays)
 using Accessors
 using Accessors: only  # for 1.3-

--- a/ext/AccessorsStructArraysExt.jl
+++ b/ext/AccessorsStructArraysExt.jl
@@ -1,4 +1,4 @@
-module StructArraysExt
+module AccessorsStructArraysExt
 using Accessors
 using StructArrays
 

--- a/src/Accessors.jl
+++ b/src/Accessors.jl
@@ -17,7 +17,7 @@ if !isdefined(Base, :get_extension)
 end
 @static if !isdefined(Base, :get_extension)
     function __init__()
-        @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" include("../ext/StaticArraysExt.jl")
+        @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" include("../ext/AccessorsStaticArraysExt.jl")
     end
 end
 


### PR DESCRIPTION
- This prevents clash of extension names.
- Currently, clashes with ConstructionBase.jl.
- - And clashing names throw fatal errors while building sysimages.
- See: https://github.com/JuliaObjects/ConstructionBase.jl/pull/78

