### PR TITLE
remove StaticArrays from hard deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,6 @@ InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
-StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [weakdeps]


### PR DESCRIPTION
It's really not needed for anything, neither on 1.9- nor on 1.9.
I added it in https://github.com/JuliaObjects/Accessors.jl/pull/78 just by mistake, and after that StaticArrays were always installed with Accessors on 1.9-.