### PR TITLE
separate Project.toml for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - 1.3 # Supporting < 1.3 is awkward since we can't do var"\bbsemi"
           - 1.6 # LTS
           - 1
           - 'nightly'

--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,6 @@ authors = ["Takafumi Arakaki <aka.tkf@gmail.com>", "Jan Weidner <jw3126@gmail.co
 version = "0.1.31"
 
 [deps]
-Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 CompositionsBase = "a33af91c-f02d-484b-be07-31d278c5ca2b"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -28,16 +27,15 @@ AccessorsStructArraysExt = "StructArrays"
 
 [compat]
 AxisKeys = "0.2"
-Compat = "3.18, 4"
 CompositionsBase = "0.1"
 ConstructionBase = "1.5"
 IntervalSets = "0.7"
 InverseFunctions = "0.1.5"
-MacroTools = "0.4.4, 0.5"
+MacroTools = "0.5"
 Requires = "0.5, 1.0"
 StaticArrays = "1"
 StructArrays = "0.6"
-julia = "1.3"
+julia = "1.6"
 
 [extras]
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"

--- a/ext/AccessorsStaticArraysExt.jl
+++ b/ext/AccessorsStaticArraysExt.jl
@@ -1,7 +1,6 @@
 module AccessorsStaticArraysExt
 isdefined(Base, :get_extension) ? (import StaticArrays) : (import ..StaticArrays)
 using Accessors
-using Accessors: only  # for 1.3-
 import Accessors: setindex, delete, insert
 
 @inline setindex(a::StaticArrays.StaticArray, args...) = Base.setindex(a, args...)

--- a/src/Accessors.jl
+++ b/src/Accessors.jl
@@ -4,14 +4,6 @@ using MacroTools: isstructdef, splitstructdef, postwalk
 using InverseFunctions
 
 
-if !isdefined(Base, :only)
-    # Julia pre-1.4
-    function only(x)
-        length(x) == 1 || throw(ArgumentError("Collection contains $(length(x)) elements, must contain exactly 1 element"))
-        first(x)
-    end
-end
-
 if !isdefined(Base, :get_extension)
     using Requires
 end

--- a/src/optics.jl
+++ b/src/optics.jl
@@ -102,26 +102,7 @@ julia> lens(obj)
 """
 opcompose
 
-const BASE_COMPOSED_FUNCTION_HAS_SHOW = VERSION >= v"1.6.0-DEV.85"
-const BASE_COMPOSED_FUNCTION_IS_PUBLIC = VERSION >= v"1.6.0-DEV.1037"
-if !BASE_COMPOSED_FUNCTION_IS_PUBLIC
-    using Compat: ComposedFunction
-end
-if !BASE_COMPOSED_FUNCTION_HAS_SHOW
-    function show_composed_function(io::IO, c::ComposedFunction)
-        show(io, c.outer)
-        print(io, " ∘ ")
-        show(io, c.inner)
-    end
-    function Base.show(io::IO, c::ComposedFunction)
-        show_composed_function(io, c)
-    end
-    function Base.show(io::IO, ::MIME"text/plain", c::ComposedFunction)
-        show_composed_function(io, c)
-    end
-end
-
-const ComposedOptic{Outer,Inner}                                        = ComposedFunction{Outer,Inner}
+const ComposedOptic{Outer,Inner} = ComposedFunction{Outer,Inner}
 outertype(::Type{ComposedOptic{Outer,Inner}}) where {Outer,Inner} = Outer
 innertype(::Type{ComposedOptic{Outer,Inner}}) where {Outer,Inner} = Inner
 

--- a/src/setindex.jl
+++ b/src/setindex.jl
@@ -34,9 +34,6 @@ end
 
 @inline setindex(x::NamedTuple{names}, v, i::Int) where {names} = NamedTuple{names}(setindex(values(x), v, i))
 
-# copied from Base: this method doesn't exist in Julia 1.3
-@inline setindex(nt::NamedTuple, v, idx::Symbol) = merge(nt, (; idx => v))
-
 @inline setindex(nt::NamedTuple, v, idx::Tuple{Vararg{Symbol}}) = merge(nt, NamedTuple{idx}(v))
 
 @inline setindex(p::Pair, v, idx::Integer) = Pair(setindex(Tuple(p), v, idx)...)

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -430,33 +430,31 @@ macro accessor(ex)
     end |> esc
 end
 
-if BASE_COMPOSED_FUNCTION_HAS_SHOW
-    _shortstring(prev, o::PropertyLens{field}) where {field} = "$prev.$field"
-    _shortstring(prev, o::IndexLens) ="$prev[$(join(repr.(o.indices), ", "))]"
-    _shortstring(prev, o::Function) = "$o($prev)"
-    _shortstring(prev, o::Base.Fix1) = "$(o.f)($(o.x), $prev)"
-    _shortstring(prev, o::Base.Fix2) = "$(o.f)($prev, $(o.x))"
+_shortstring(prev, o::PropertyLens{field}) where {field} = "$prev.$field"
+_shortstring(prev, o::IndexLens) ="$prev[$(join(repr.(o.indices), ", "))]"
+_shortstring(prev, o::Function) = "$o($prev)"
+_shortstring(prev, o::Base.Fix1) = "$(o.f)($(o.x), $prev)"
+_shortstring(prev, o::Base.Fix2) = "$(o.f)($prev, $(o.x))"
 
-    function show_optic(io, optic)
-        opts = deopcompose(optic)
-        inner = Iterators.takewhile(x -> applicable(_shortstring, "", x), opts)
-        outer = Iterators.dropwhile(x -> applicable(_shortstring, "", x), opts)
-        if !isempty(outer)
-            show(io, opcompose(outer...))
-            print(io, " ∘ ")
-        end
-        print(io, "(@optic ", reduce(_shortstring, inner; init="_"), ")")
+function show_optic(io, optic)
+    opts = deopcompose(optic)
+    inner = Iterators.takewhile(x -> applicable(_shortstring, "", x), opts)
+    outer = Iterators.dropwhile(x -> applicable(_shortstring, "", x), opts)
+    if !isempty(outer)
+        show(io, opcompose(outer...))
+        print(io, " ∘ ")
     end
-
-    Base.show(io::IO, optic::Union{IndexLens, PropertyLens}) = print(io, "(@optic $(_shortstring("_", optic)))")
-
-    Base.show(io::IO, optic::ComposedFunction{<:Any, <:Union{IndexLens, PropertyLens}}) = show_optic(io, optic)
-    # resolve method ambiguity:
-    Base.show(io::IO, optic::ComposedFunction{typeof(!), <:Union{IndexLens, PropertyLens}}) = show_optic(io, optic)
-
-    Base.show(io::IO, ::MIME"text/plain", optic::Union{IndexLens, PropertyLens}) = show(io, optic)
-    Base.show(io::IO, ::MIME"text/plain", optic::ComposedFunction{<:Any, <:Union{IndexLens, PropertyLens}}) = show(io, optic)    
+    print(io, "(@optic ", reduce(_shortstring, inner; init="_"), ")")
 end
+
+Base.show(io::IO, optic::Union{IndexLens, PropertyLens}) = print(io, "(@optic $(_shortstring("_", optic)))")
+
+Base.show(io::IO, optic::ComposedFunction{<:Any, <:Union{IndexLens, PropertyLens}}) = show_optic(io, optic)
+# resolve method ambiguity:
+Base.show(io::IO, optic::ComposedFunction{typeof(!), <:Union{IndexLens, PropertyLens}}) = show_optic(io, optic)
+
+Base.show(io::IO, ::MIME"text/plain", optic::Union{IndexLens, PropertyLens}) = show(io, optic)
+Base.show(io::IO, ::MIME"text/plain", optic::ComposedFunction{<:Any, <:Union{IndexLens, PropertyLens}}) = show(io, optic)
 
 # debugging
 show_composition_order(optic) = (show_composition_order(stdout, optic); println())

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -19,11 +19,11 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Aqua = "0.6"
-AxisKeys = "0.1,0.2"  # only AxisKeys 0.2 is actually supported, but 0.1 compat is required to run tests on Julia 1.3
+AxisKeys = "0.2"
 ConstructionBase = "1.5"
 ConstructionBaseExtras = "0.1"
 BenchmarkTools = "1.3"
-IntervalSets = "0.5,0.7"  # only IntervalSets 0.7 is actually supported, but 0.5 compat is required to run tests on Julia 1.3
+IntervalSets = "0.7"
 InverseFunctions = "0.1.5"
 MacroTools = "0.4.4, 0.5"
 PerformanceTestTools = "0.1.3"

--- a/test/test_delete.jl
+++ b/test/test_delete.jl
@@ -12,7 +12,7 @@ using StaticArrays
         @test @inferred(delete((1, 2), @optic(_[1]))) == (2,)
         @test delete( (a=1, b=2, c=3), @optic(_[:a]) ) == (b=2, c=3)
         @test delete( (1,2,3), last ) == (1, 2)
-        VERSION >= v"1.6" && @inferred(delete( (1,2,3), last ))
+        @inferred(delete( (1,2,3), last ))
         f(t) = delete(t, @optic(_[1:2]))
         @test @inferred(f((1,2,3))) == (3,)
         @test @inferred(delete( (a=1, b=2, c=3), first ))== (b=2, c=3)
@@ -21,7 +21,7 @@ using StaticArrays
         @test @inferred(delete( [1, 2, 3], @optic(last(_, 2)))) == [1]
 
         l = @optic first(_, 2)
-        VERSION >= v"1.6" && @test l((1,2,3)) == [1,2]
+        @test l((1,2,3)) == [1,2]
         @test delete((1,2,3), l) === (3,)
 
         @test delete("абв", first) == "бв"

--- a/test/test_extensions.jl
+++ b/test/test_extensions.jl
@@ -80,7 +80,7 @@ end
     @test (@set v[1] = 10) === @SVector [10.,2,3]
     @test (@set v[1] = π) === @SVector [π,2,3]
     # requires ConstructionBase extension:
-    VERSION >= v"1.9-DEV" && @test (@set v.x = 10) === @SVector [10.,2,3]
+    VERSION >= v"1.9-" && @test (@set v.x = 10) === @SVector [10.,2,3]
 
     @testset "Multi-dynamic indexing" begin
         two = 2

--- a/test/test_getsetall.jl
+++ b/test/test_getsetall.jl
@@ -9,7 +9,6 @@ using StaticArrays
     using ConstructionBaseExtras
 end
 
-if VERSION >= v"1.6"  # for ComposedFunction
 @testset "getall" begin
     obj = (a=1, b=2.0, c='3')
     @test (1,) === @inferred getall(obj, @optic _.a)
@@ -150,6 +149,4 @@ end
     end
 end
         
-end
-
 end

--- a/test/test_insert.jl
+++ b/test/test_insert.jl
@@ -18,7 +18,7 @@ using Accessors: insert
             @test A == [1, 2]  # not changed
         end
         @test insert((1,2), last, 3) == (1, 2, 3)
-        Base.thisminor(VERSION) >= v"1.6" && @inferred(insert((1,2), last, 3))
+        @inferred(insert((1,2), last, 3))
         @test @inferred(insert(SVector(1,2), @optic(_[1]), 3)) == SVector(3, 1, 2)
         @test @inferred(insert(SVector(1,2), last, 3)) == SVector(1, 2, 3)
         let D = Dict(:a => 1)

--- a/test/test_setindex.jl
+++ b/test/test_setindex.jl
@@ -59,10 +59,8 @@ end
 end
 
 @testset begin
-    if VERSION >= v"1.5.0"
-        _ = ref_alloc_test()
-        @test @allocated(ref_alloc_test()) == 0
-    end
+    _ = ref_alloc_test()
+    @test @allocated(ref_alloc_test()) == 0
 end
 
 end


### PR DESCRIPTION
Following https://github.com/JuliaObjects/Accessors.jl/pull/108#discussion_r1195978792.
This split let:
- Cleanup Project.toml significantly (obvious)
- Specify proper compat versions for weakdeps, see AxisKeys and IntervalSets
- Catch and fix missing compats for several test dependencies