### PR TITLE
fix tests on 1.10

### DIFF
--- a/test/perf.jl
+++ b/test/perf.jl
@@ -177,7 +177,9 @@ end
     println("Right associative composition: $b_right")
 
     @test b_default.allocs == 0
-    if VERSION >= v"1.7"
+    if VERSION >= v"1.10-"
+        @test_broken b_right.allocs == 0
+    elseif VERSION >= v"1.7"
         @test b_right.allocs == 0
     else
         @test_broken right.allocs == 0

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -201,13 +201,10 @@ end
           ((@optic _.b.a.b[end]),     4.0),
           ((@optic _.b.a.b[end÷2+1]), 4.0),
          ]
-        if VERSION < v"1.7"
-            @test begin
-                @inferred lens(obj)
-                @inferred set(obj, lens, val)
-                @inferred modify(identity, obj, lens)
-                true
-            end
+        if VERSION < v"1.7" || VERSION >= v"1.10-"
+            @inferred lens(obj)
+            @inferred set(obj, lens, val)
+            @inferred modify(identity, obj, lens)
         else
             @inferred lens(obj)
             @inferred set(obj, lens, val)


### PR DESCRIPTION
Only one minor regression: in allocations when the compose order is right-associative