### PR TITLE
remove/soften "experimental" warnings

### DIFF
--- a/src/getsetall.jl
+++ b/src/getsetall.jl
@@ -4,7 +4,7 @@
 Extract all parts of `obj` that are selected by `optic`.
 Returns a flat `Tuple` of values, or an `AbstractVector` if the selected parts contain arrays.
 
-This function is experimental and we might change the precise output container in the future.
+The details of `getall` behavior are consireded experimental: in particular, the precise output container type might change in the future.
 
 See also [`setall`](@ref).
 
@@ -29,7 +29,7 @@ function getall end
 Replace a part of `obj` that is selected by `optic` with `values`.
 The `values` collection should have the same number of elements as selected by `optic`.
 
-This function is experimental and might change in the future.
+The details of `setall` behavior are consireded experimental: in particular, supported container types for the `values` argument might change in the future.
 
 See also [`getall`](@ref), [`set`](@ref). The former is dual to `setall`:
 

--- a/src/optics.jl
+++ b/src/optics.jl
@@ -9,7 +9,7 @@ using CompositionsBase
 using Base: getproperty
 using Base
 
-const EXPERIMENTAL = """This function/method/type is experimental. It can be changed or deleted at any point without warning"""
+const EXPERIMENTAL = """This function/type is experimental. It can be changed or deleted at any point without warning"""
 
 """
     modify(f, obj, optic)
@@ -223,7 +223,6 @@ julia> set(obj, Elements(), 0)
 julia> modify(x -> 2x, obj, Elements())
 (2, 4, 6)
 ```
-$EXPERIMENTAL
 """
 struct Elements end
 OpticStyle(::Type{<:Elements}) = ModifyBased()
@@ -313,8 +312,6 @@ julia> modify(x -> 2x, obj, Properties())
 (a = 2, b = 4, c = 6)
 ```
 Based on [`mapproperties`](@ref).
-
-$EXPERIMENTAL
 """
 struct Properties end
 OpticStyle(::Type{<:Properties}) = ModifyBased()


### PR DESCRIPTION
- Elements() and Properties() aren't experimental anymore
- getall and setall docstring made more concrete

I hope it better reflects the actual state of these.