### PR TITLE
Support `insert` with dynamic `DynamicIndexLens`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Accessors"
 uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>", "Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "0.1.35"
+version = "0.1.36"
 
 [deps]
 CompositionsBase = "a33af91c-f02d-484b-be07-31d278c5ca2b"

--- a/src/optics.jl
+++ b/src/optics.jl
@@ -455,6 +455,10 @@ end
     delete(obj, IndexLens(lens.f(obj)))
 end
 
+Base.@propagate_inbounds function insert(obj, lens::DynamicIndexLens, x)
+    insert(obj, IndexLens(lens.f(obj)), x)
+end
+
 
 Broadcast.broadcastable(
     o::Union{PropertyLens,IndexLens,DynamicIndexLens,Elements,Properties,If,Recursive}

--- a/test/test_insert.jl
+++ b/test/test_insert.jl
@@ -8,6 +8,7 @@ using Accessors: insert
     @testset "function" begin
         @test @inferred(insert( (b=2, c=3), @optic(_.a), 1 )) == (b=2, c=3, a=1)
         @test insert( (b=2, c=3), @optic(_[:a]), 1 ) == (b=2, c=3, a=1)
+        @test insert( (2, 3), @optic(_[end]), 1) == (2, 3, 1)
         let A = [1, 2]
             @test insert(A, @optic(_[2]), 3) == [1, 3, 2]
             @test_throws BoundsError insert(A, @optic(_[4]), 3)
@@ -15,6 +16,8 @@ using Accessors: insert
             @test insert(A, first, 3) == [3, 1, 2]
             @test insert(A, @optic(first(_, 2)), [3, 4]) == [3, 4, 1, 2]
             @test insert(A, @optic(last(_, 2)), [3, 4]) == [1, 2, 3, 4]
+            @test insert(A, @optic(_[end+1]), 3) == [1, 2, 3]
+            @test insert(A, @optic(_[(end+1):(end+2)]), [3, 4]) == [1, 2, 3, 4]
             @test A == [1, 2]  # not changed
         end
         @test @inferred(insert(CartesianIndex(1, 2, 3), @optic(_[2]), 4)) == CartesianIndex(1, 4, 2, 3)
@@ -41,6 +44,8 @@ using Accessors: insert
         @test @insert(x[(:a, :x)] = (x=:xyz, a=1)) === (b=2, c=3, a=1, x=:xyz)
         x = [1, 2]
         @test @insert(x[3] = 3) == [1, 2, 3]
+        @test @insert(x[end+1] = 3) == [1, 2, 3]
+        @test @insert(x[end] = 3) == [1, 3]
         x = (a=(b=(1, 2),), c=1)
         @test @insert(x.a.b[1] = 0) == (a=(b=(0, 1, 2),), c=1)
 

--- a/test/test_insert.jl
+++ b/test/test_insert.jl
@@ -8,7 +8,7 @@ using Accessors: insert
     @testset "function" begin
         @test @inferred(insert( (b=2, c=3), @optic(_.a), 1 )) == (b=2, c=3, a=1)
         @test insert( (b=2, c=3), @optic(_[:a]), 1 ) == (b=2, c=3, a=1)
-        @test insert( (2, 3), @optic(_[end]), 1) == (2, 3, 1)
+        @test insert( (2, 3), @optic(_[end]), 1) == (2, 1, 3)
         let A = [1, 2]
             @test insert(A, @optic(_[2]), 3) == [1, 3, 2]
             @test_throws BoundsError insert(A, @optic(_[4]), 3)
@@ -45,7 +45,7 @@ using Accessors: insert
         x = [1, 2]
         @test @insert(x[3] = 3) == [1, 2, 3]
         @test @insert(x[end+1] = 3) == [1, 2, 3]
-        @test @insert(x[end] = 3) == [1, 3]
+        @test @insert(x[end] = 3) == [1, 3, 2]
         x = (a=(b=(1, 2),), c=1)
         @test @insert(x.a.b[1] = 0) == (a=(b=(0, 1, 2),), c=1)
 


### PR DESCRIPTION
Before:
```julia
julia> let v = [1,2,3]
           @insert v[end+1] = 4
       end
ERROR: MethodError: no method matching insert(::Vector{Int64}, ::Accessors.DynamicIndexLens{var"#6#7"}, ::Int64)
```
after:
```julia
julia> let v = [1,2,3]
           @insert v[end+1] = 4
       end
4-element Vector{Int64}:
 1
 2
 3
 4
```