### PR TITLE
Define error hint for `insert` on `DynamicIndexLens`.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Accessors"
 uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>", "Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "0.1.35"
+version = "0.1.36"
 
 [deps]
 CompositionsBase = "a33af91c-f02d-484b-be07-31d278c5ca2b"
@@ -10,6 +10,7 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/Accessors.jl
+++ b/src/Accessors.jl
@@ -2,7 +2,7 @@ module Accessors
 using MacroTools
 using MacroTools: isstructdef, splitstructdef, postwalk
 using InverseFunctions
-
+using Markdown: Markdown, @md_str, term
 
 if !isdefined(Base, :get_extension)
     using Requires
@@ -24,5 +24,33 @@ include("testing.jl")
 include("../ext/AccessorsDatesExt.jl")
 include("../ext/AccessorsLinearAlgebraExt.jl")
 include("../ext/AccessorsTestExt.jl")
+
+function __init__()
+    if isdefined(Base.Experimental, :register_error_hint)
+        Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
+            if exc.f === insert && argtypes[2] <: Accessors.DynamicIndexLens
+                println(io)
+                term(io, md"""
+                   `insert` with a `DynamicIndexLens` is not supported, this can happen when you write
+                   code such as `@insert a[end] = 1` or `@insert a[begin] = 1` since `end` and `begin`
+                   are functions of `a`. The reason we do not support these with `insert` is that 
+                   Accessors.jl tries to guarentee that `f(insert(obj, f, val)) == val`, but 
+                   `@insert a[end] = 1` and `@insert a[begin] = 1` will violate that invariant.
+                   
+                   Instead, you can use `first` and `last` directly, e.g.
+                   ```
+                   julia> a = (1, 2, 3, 4)
+                   
+                   julia> @insert last(a) = 5
+                   (1, 2, 3, 4, 5)
+                   
+                   julia> @insert first(a) = 0
+                   (0, 1, 2, 3, 4)
+                   ```
+                   """)
+            end
+        end
+    end
+end
 
 end


### PR DESCRIPTION
Alternative to https://github.com/JuliaObjects/Accessors.jl/pull/132

Here's what it looks like when a user hits the error:
![image](https://github.com/JuliaObjects/Accessors.jl/assets/29157027/7fa953e2-5013-4077-9a24-853ad2076dad)

I went kinda maximalist on the description, but if we want we can slim it down a lot. 