### PR TITLE
nicer show for optics

### DIFF
--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -462,6 +462,8 @@ end
 @testset "full and compact show" begin
     @test sprint(show, (@optic _.a)) == "(@o _.a)"
     @test sprint(show, (@optic _.a + 1)) == "(@o _.a + 1)"
+    @test sprint(show, (@optic (_.a + 1) * 2)) == "(@o (_.a + 1) * 2)"
+    @test sprint(show, (@optic (_.a * 2) + 1)) == "(@o (_.a * 2) + 1)"
     @test sprint(show, (@optic log(_.a[2]))) == "(@o log(_.a[2]))"
     @test sprint(show, (@optic log(_).a[2])) == "(@o _.a[2]) ∘ log"  # could be shorter, but difficult to dispatch correctly without piracy
     @test sprint(show, (@optic log(_.a[2])); context=:compact => true) == "log(_.a[2])"

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -461,6 +461,7 @@ end
 
 @testset "full and compact show" begin
     @test sprint(show, (@optic _.a)) == "(@o _.a)"
+    @test sprint(show, (@optic _.a + 1)) == "(@o _.a + 1)"
     @test sprint(show, (@optic log(_.a[2]))) == "(@o log(_.a[2]))"
     @test sprint(show, (@optic log(_).a[2])) == "(@o _.a[2]) ∘ log"  # could be shorter, but difficult to dispatch correctly without piracy
     @test sprint(show, (@optic log(_.a[2])); context=:compact => true) == "log(_.a[2])"
@@ -512,6 +513,7 @@ end
             (@optic _.a) ∘ UserDefinedLens()   ∘ (@optic _.b)
             (@optic _.a) ∘ LensIfTextPlain() ∘ (@optic _.b)
             @optic 2 * (abs(_.a.b[2].c) + 1)
+            @optic 2 * (-(abs(_.a.b[2].c) + 1))
             @optic !(_.a) # issue 105
         ]
         buf = IOBuffer()


### PR DESCRIPTION
Optics already show quite nicely in many cases, with a major exception of operators. Here, I make operators display nicer, while staying conservative to ensure robust show-parse roundtrip:
```julia
julia> @o _.a + 1
(@o +(_.a, 1)) # before
(@o _.a + 1) # after

julia> @o _.a*2 + 1
(@o +(*(_.a, 2), 1)) # before
(@o (_.a * 2) + 1) # after
```
Most useful whenever optics are a part of the user-facing interface (can even be plot labels!), but for internal debug/inspection as well.