### PR TITLE
Move custom error hint for insert to a package extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,6 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 InverseFunctions = "3587e190-3f89-42d0-90ee-14403ec27112"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MacroTools = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
@@ -21,6 +20,7 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [extensions]
 AccessorsAxisKeysExt = "AxisKeys"
@@ -28,6 +28,7 @@ AccessorsIntervalSetsExt = "IntervalSets"
 AccessorsStaticArraysExt = "StaticArrays"
 AccessorsStructArraysExt = "StructArrays"
 AccessorsUnitfulExt = "Unitful"
+AccessorsMarkdownExt = "Markdown"
 
 [compat]
 AxisKeys = "0.2"

--- a/src/Accessors.jl
+++ b/src/Accessors.jl
@@ -2,7 +2,6 @@ module Accessors
 using MacroTools
 using MacroTools: isstructdef, splitstructdef, postwalk
 using InverseFunctions
-using Markdown: Markdown, @md_str, term
 
 if !isdefined(Base, :get_extension)
     using Requires
@@ -24,31 +23,6 @@ include("../ext/AccessorsTestExt.jl")
 function __init__()
     @static if !isdefined(Base, :get_extension)
         @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" include("../ext/AccessorsStaticArraysExt.jl")
-    end
-    if isdefined(Base.Experimental, :register_error_hint)
-        Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs
-            if exc.f === insert && argtypes[2] <: Accessors.DynamicIndexLens
-                println(io)
-                term(io, md"""
-                   `insert` with a `DynamicIndexLens` is not supported, this can happen when you write
-                   code such as `@insert a[end] = 1` or `@insert a[begin] = 1` since `end` and `begin`
-                   are functions of `a`. The reason we do not support these with `insert` is that 
-                   Accessors.jl tries to guarentee that `f(insert(obj, f, val)) == val`, but 
-                   `@insert a[end] = 1` and `@insert a[begin] = 1` will violate that invariant.
-                   
-                   Instead, you can use `first` and `last` directly, e.g.
-                   ```
-                   julia> a = (1, 2, 3, 4)
-                   
-                   julia> @insert last(a) = 5
-                   (1, 2, 3, 4, 5)
-                   
-                   julia> @insert first(a) = 0
-                   (0, 1, 2, 3, 4)
-                   ```
-                   """)
-            end
-        end
     end
 end
 


### PR DESCRIPTION
This is a followup PR to https://github.com/JuliaObjects/Accessors.jl/pull/140

On modern versions of julia, moving this code to a package extension should have no observable changes, but it makes it so that Accessors.jl doesn't unconditionally load Markdown.jl, and only ends up using it *if* it's already loaded (which will be the case for interactive sessions of julia, but might *not* be the case if one is doing something like making a small binary and are stripping stdlibs. 

I'd argue that in such a situation, this error hint isn't necessary or desirable anyways. 