### PR TITLE
improve error message

### DIFF
--- a/src/optics.jl
+++ b/src/optics.jl
@@ -171,7 +171,7 @@ function _set(obj, optic, val, ::SetBased)
     Optic = typeof(optic)
     error("""
     This should be unreachable. You probably need to overload
-    `Accessors.set(obj, ::$Optic, val)
+    `Accessors.set(obj::$(nameof(typeof(obj))), ::$Optic, val::$(nameof(typeof(val))))`
     """)
 end
 
@@ -201,9 +201,9 @@ end
 function _modify(f, obj, optic, ::ModifyBased)
     Optic = typeof(optic)
     error("""
-          This should be unreachable. You probably need to overload:
-          `Accessors.modify(f, obj, ::$Optic)`
-          """)
+    This should be unreachable. You probably need to overload:
+    `Accessors.modify(f, obj::$(nameof(typeof(obj))), ::$Optic)`
+    """)
 end
 
 function _modify(f, obj, optic::ComposedOptic, ::ModifyBased)


### PR DESCRIPTION
Was a bit confusing, eg:
```julia
julia> set(1, year, 123)
ERROR: This should be unreachable. You probably need to overload
`Accessors.set(obj, ::typeof(year), val)
```
even though `set()` with `year` already exists, but defined for dates only.
With this PR:
```julia
julia> set(1, year, 123)
ERROR: This should be unreachable. You probably need to overload
`Accessors.set(obj::Int64, ::typeof(year), val::Int64)`
```