### PR TITLE
Make Dates and Tests weak dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Accessors"
 uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>", "Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "0.1.37"
+version = "0.1.38"
 
 [deps]
 CompositionsBase = "a33af91c-f02d-484b-be07-31d278c5ca2b"
@@ -16,17 +16,21 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [weakdeps]
 AxisKeys = "94b1ba4f-4ee9-5380-92f1-94cde586c3c5"
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
 AccessorsAxisKeysExt = "AxisKeys"
+AccessorsDatesExt = "Dates"
 AccessorsIntervalSetsExt = "IntervalSets"
 AccessorsStaticArraysExt = "StaticArrays"
 AccessorsStructArraysExt = "StructArrays"
+AccessorsTestExt = "Test"
 AccessorsUnitfulExt = "Unitful"
 
 [compat]

--- a/src/Accessors.jl
+++ b/src/Accessors.jl
@@ -17,9 +17,12 @@ include("functionlenses.jl")
 include("testing.jl")
 
 # always included for now
-include("../ext/AccessorsDatesExt.jl")
 include("../ext/AccessorsLinearAlgebraExt.jl")
-include("../ext/AccessorsTestExt.jl")
+
+if !isdefined(Base, :get_extension)
+    include("../ext/AccessorsDatesExt.jl")
+    include("../ext/AccessorsTestExt.jl")
+end
 
 function __init__()
     @static if !isdefined(Base, :get_extension)
@@ -47,6 +50,8 @@ function __init__()
                    (0, 1, 2, 3, 4)
                    ```
                    """)
+            elseif (exc.f === test_getset_laws || exc.f === test_modify_law || exc.f === test_getsetall_laws || exc.f === test_insertdelete_laws) && isdefined(Base, :get_extension) && Base.get_extension(Accessors, :AccessorsTestExt) === nothing
+                print(io, "\nDid you forget to load Test?")
             end
         end
     end


### PR DESCRIPTION
LinearAlgebra is kept as a direct dependency until https://github.com/JuliaObjects/ConstructionBase.jl/pull/95 is released: Without that PR, LinearAlgebra is a transitive dependency of Accessors and hence a LinearAlgebra extension of Accessors is not useful (and will even lead to warnings).