### PR TITLE
fix trivial @accessor functions

### DIFF
--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -248,6 +248,10 @@ function parse_obj_optics(ex)
             obj, frontoptic = parse_obj_optics(args[2])
             optic = :(Base.Fix1($f, $(esc(args[1]))))
         end
+    elseif @capture(ex, s_Symbol)
+        # the symbol can be wrapped in quote ... end, need to unwrap for reliable handling downstream
+        obj = esc(s)
+        return obj, ()
     else
         obj = esc(ex)
         return obj, ()

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -598,6 +598,7 @@ struct MyStruct
 end
 "Documentation for my_x"
 @accessor my_x(v) = v.x
+@accessor my_identity(v) = v
 @accessor Base.:(+)(s::MyStruct) = 5 - s.x.a
 @accessor Base.Int(s::MyStruct) = s.x[1]
 @accessor Base.Float64(s::MyStruct) = s.x[2]
@@ -613,6 +614,7 @@ import REPL
     @test (@set my_x(s) = 456) === MyStruct(456)
     @test (@set +s = 456) === MyStruct((a=5-456,))
     test_getset_laws(my_x, s, 456, "1")
+    test_getset_laws(my_identity, 123, 456, "1")
     test_getset_laws(+, s, 456, 1.0)
 
     s = MyStruct((1, 2.0))


### PR DESCRIPTION
`@accessor f(x) = x` triggered some edgecase in parsing, fixed now.

Can be reproduced with regular `@optic` macros without `@accessor`, but probably noone write optics like this:
```julia
# worked before as well:
julia> @optic begin
       _ + 1
       end
(::Base.Fix2{typeof(+), Int64}) (generic function with 1 method)

# threw an error before:
julia> @optic begin
       _
       end
identity (generic function with 1 method)
```