### PR TITLE
use shorter extension names

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,14 +26,14 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [extensions]
-AccessorsAxisKeysExt = "AxisKeys"
-AccessorsDatesExt = "Dates"
-AccessorsIntervalSetsExt = "IntervalSets"
-AccessorsLinearAlgebraExt = "LinearAlgebra"
-AccessorsStaticArraysExt = "StaticArrays"
-AccessorsStructArraysExt = "StructArrays"
-AccessorsTestExt = "Test"
-AccessorsUnitfulExt = "Unitful"
+AxisKeysExt = "AxisKeys"
+DatesExt = "Dates"
+IntervalSetsExt = "IntervalSets"
+LinearAlgebraExt = "LinearAlgebra"
+StaticArraysExt = "StaticArrays"
+StructArraysExt = "StructArrays"
+TestExt = "Test"
+UnitfulExt = "Unitful"
 
 [compat]
 AxisKeys = "0.2"

--- a/ext/AxisKeysExt.jl
+++ b/ext/AxisKeysExt.jl
@@ -1,4 +1,4 @@
-module AccessorsAxisKeysExt
+module AxisKeysExt
 using Accessors
 using AxisKeys
 

--- a/ext/DatesExt.jl
+++ b/ext/DatesExt.jl
@@ -1,4 +1,4 @@
-module AccessorsDatesExt
+module DatesExt
 
 using Accessors
 import Accessors: set

--- a/ext/IntervalSetsExt.jl
+++ b/ext/IntervalSetsExt.jl
@@ -1,4 +1,4 @@
-module AccessorsIntervalSetsExt
+module IntervalSetsExt
 using Accessors
 using IntervalSets
 

--- a/ext/LinearAlgebraExt.jl
+++ b/ext/LinearAlgebraExt.jl
@@ -1,4 +1,4 @@
-module AccessorsLinearAlgebraExt
+module LinearAlgebraExt
 
 import Accessors: set, @set
 using LinearAlgebra: norm, normalize, diag, diagind

--- a/ext/StaticArraysExt.jl
+++ b/ext/StaticArraysExt.jl
@@ -1,4 +1,4 @@
-module AccessorsStaticArraysExt
+module StaticArraysExt
 isdefined(Base, :get_extension) ? (using StaticArrays) : (using ..StaticArrays)
 using Accessors
 import Accessors: setindex, delete, insert

--- a/ext/StructArraysExt.jl
+++ b/ext/StructArraysExt.jl
@@ -1,4 +1,4 @@
-module AccessorsStructArraysExt
+module StructArraysExt
 using Accessors
 using StructArrays
 

--- a/ext/TestExt.jl
+++ b/ext/TestExt.jl
@@ -1,4 +1,4 @@
-module AccessorsTestExt
+module TestExt
 
 using Accessors
 using Test: @test

--- a/ext/UnitfulExt.jl
+++ b/ext/UnitfulExt.jl
@@ -1,4 +1,4 @@
-module AccessorsUnitfulExt
+module UnitfulExt
 
 import Accessors: set
 using Unitful

--- a/src/Accessors.jl
+++ b/src/Accessors.jl
@@ -17,14 +17,14 @@ include("functionlenses.jl")
 include("testing.jl")
 
 if !isdefined(Base, :get_extension)
-    include("../ext/AccessorsDatesExt.jl")
-    include("../ext/AccessorsLinearAlgebraExt.jl")
-    include("../ext/AccessorsTestExt.jl")
+    include("../ext/DatesExt.jl")
+    include("../ext/LinearAlgebraExt.jl")
+    include("../ext/TestExt.jl")
 end
 
 function __init__()
     @static if !isdefined(Base, :get_extension)
-        @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" include("../ext/AccessorsStaticArraysExt.jl")
+        @require StaticArrays = "90137ffa-7385-5640-81b9-e52037218182" include("../ext/StaticArraysExt.jl")
     end
     if isdefined(Base.Experimental, :register_error_hint)
         Base.Experimental.register_error_hint(MethodError) do io, exc, argtypes, kwargs


### PR DESCRIPTION
The shorter names have been recommended for quite some time already, see https://pkgdocs.julialang.org/v1/creating-packages/#Conditional-loading-of-code-in-packages-(Extensions). Actually, there was only a short period of time early during 1.9 version, when some tooling didn't work with these shorter names. Now, they only serve to clutter precompilation output :)