### PR TITLE
CI settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: 1.7
+          version: '1.10'
       - run: |
           julia --project=docs -e '
             using Pkg

--- a/src/optics.jl
+++ b/src/optics.jl
@@ -118,7 +118,7 @@ julia> la = @optic _.a
        lb = @optic _.b
        lc = @optic _.c
        lens = la ⨟ lb ⨟ lc
-(@o _.c) ∘ (@o _.a.b)
+(@o _.c) ∘ ((@o _.a.b))
 
 julia> lens(obj)
 1


### PR DESCRIPTION
- wasn't tested on macos for some reason – added
- tests ran on nightly, leading to failures often reported; in practice, we don't even try to fix those issues, and now that the `pre` version exists – let's just remove `nightly`
- run the Documentation workflow on 1.10