### PR TITLE
tweak NamedTuple operations to be more type-stable

### DIFF
--- a/src/optics.jl
+++ b/src/optics.jl
@@ -389,6 +389,7 @@ function (l::PropertyLens{field})(obj) where {field}
     getproperty(obj, field)
 end
 
+# Julia seems to prefers if types stay in the type domain the whole time like NamedTuple{(field,)}, instead of going through the value domain and constprop like (; field => val)
 @inline set(obj, l::PropertyLens{field}, val) where {field} = setproperties(obj, NamedTuple{(field,)}((val,)))
 @inline delete(obj::NamedTuple, l::PropertyLens{field}) where {field} = Base.structdiff(obj, NamedTuple{(field,)})
 @inline insert(obj::NamedTuple{KS}, l::PropertyLens{field}, val) where {KS, field} = NamedTuple{(KS..., field)}((values(obj)..., val))


### PR DESCRIPTION
Don't know how to make a self-contained test for it, but found that this change improves stability in some cases.
I guess Julia prefers if types stay in the type domain the whole time (as in `NamedTuple{(field,)}`), instead of going through the value domain and constprop (as in `(; field => val)`).