### PR TITLE
Allow for proposed new parsing of `array[end]` in Accessors

### DIFF
--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -141,7 +141,7 @@ foldtree(op, init, ex::Expr) =
 
 need_dynamic_optic(ex) =
     foldtree(false, ex) do yes, x
-        yes || x === :end || x === :begin || x == Expr(:end) || x == Expr(:begin) || x === :_
+        yes || x ∈ (:end, :begin, Expr(:end), Expr(:begin), :_)
     end
 
 replace_underscore(ex, to) = postwalk(x -> x === :_ ? to : x, ex)

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -147,23 +147,13 @@ need_dynamic_optic(ex) =
 replace_underscore(ex, to) = postwalk(x -> x === :_ ? to : x, ex)
 
 function lower_index(collection::Symbol, index, dim)
-    index = MacroTools.replace(
-        index, :end,
-        dim === nothing ? :($(Base.lastindex)($collection)) : :($(Base.lastindex)($collection, $dim))
-    )
-    index = MacroTools.replace(
-        index, :begin,
-        dim === nothing ? :($(Base.firstindex)($collection)) : :($(Base.firstindex)($collection, $dim))
-    )
+    lasti = dim === nothing ? :($(Base.lastindex)($collection)) : :($(Base.lastindex)($collection, $dim))
+    firsti = dim === nothing ? :($(Base.firstindex)($collection)) : :($(Base.firstindex)($collection, $dim))
+    index = MacroTools.replace(index, :end, lasti)
+    index = MacroTools.replace(index, :begin, firsti)
     # New syntax for begin/end in indexing expression, see https://github.com/JuliaLang/julia/pull/57368
-    index = MacroTools.replace(
-        index, Expr(:end),
-        dim === nothing ? :($(Base.lastindex)($collection)) : :($(Base.lastindex)($collection, $dim))
-    )
-    index = MacroTools.replace(
-        index, Expr(:begin),
-        dim === nothing ? :($(Base.firstindex)($collection)) : :($(Base.firstindex)($collection, $dim))
-    )
+    index = MacroTools.replace(index, Expr(:end), lasti)
+    index = MacroTools.replace(index, Expr(:begin), firsti)
 end
 
 _secondarg(_, x) = x


### PR DESCRIPTION
To fix https://github.com/JuliaLang/julia/issues/57269, a small-but-breaking AST change is needed (PR https://github.com/JuliaLang/julia/pull/57368).  The `set` macro in Setfield and Accessors breaks, and enough packages depend on this macro that it needs to be updated before deciding whether to merge the julialang PR.

This PR only recognizes the new way of parsing `array[end]`, and should not change any behaviour when used with the current parser.