### PR TITLE
`set(arr, reverse, arr2)` can change size

### DIFF
--- a/ext/AxisKeysExt.jl
+++ b/ext/AxisKeysExt.jl
@@ -10,4 +10,11 @@ Accessors.set(x::KeyedArray, f::Base.Fix2{typeof(axiskeys), Int}, v) = @set axis
 Accessors.set(x::KeyedArray, f::Base.Fix2{typeof(axiskeys), Symbol}, v) = @set named_axiskeys(x)[f.x] = v
 
 Accessors.set(x::KeyedArray, ::typeof(AxisKeys.keyless_unname), v::AbstractArray) = KeyedArray(v; named_axiskeys(x)...)
+
+function set(x::AbstractVector, ::typeof(reverse), v::KeyedArray)
+    res = similar(x, eltype(v))
+    res .= v
+    reverse!(res)
+    res
+end
 end

--- a/ext/AxisKeysExt.jl
+++ b/ext/AxisKeysExt.jl
@@ -11,7 +11,7 @@ Accessors.set(x::KeyedArray, f::Base.Fix2{typeof(axiskeys), Symbol}, v) = @set n
 
 Accessors.set(x::KeyedArray, ::typeof(AxisKeys.keyless_unname), v::AbstractArray) = KeyedArray(v; named_axiskeys(x)...)
 
-function set(x::AbstractVector, ::typeof(reverse), v::KeyedArray)
+function set(x::KeyedArray, ::typeof(reverse), v)
     res = similar(x, eltype(v))
     res .= v
     reverse!(res)

--- a/ext/AxisKeysExt.jl
+++ b/ext/AxisKeysExt.jl
@@ -11,7 +11,7 @@ Accessors.set(x::KeyedArray, f::Base.Fix2{typeof(axiskeys), Symbol}, v) = @set n
 
 Accessors.set(x::KeyedArray, ::typeof(AxisKeys.keyless_unname), v::AbstractArray) = KeyedArray(v; named_axiskeys(x)...)
 
-function set(x::KeyedArray, ::typeof(reverse), v)
+function set(x::KeyedArray, ::typeof(reverse), v::AbstractVector)
     res = similar(x, eltype(v))
     res .= v
     reverse!(res)

--- a/src/functionlenses.jl
+++ b/src/functionlenses.jl
@@ -92,7 +92,7 @@ end
 set(::Tuple, ::typeof(reverse), v) = reverse(Tuple(v))
 set(x::NamedTuple, ::typeof(reverse), v) = @set reverse(Tuple(x)) = v
 function set(x::AbstractVector, ::typeof(reverse), v)
-    res = similar(x, eltype(v))
+    res = similar(x, eltype(v), size(v))
     res .= v
     reverse!(res)
     res

--- a/src/functionlenses.jl
+++ b/src/functionlenses.jl
@@ -92,6 +92,12 @@ end
 set(::Tuple, ::typeof(reverse), v) = reverse(Tuple(v))
 set(x::NamedTuple, ::typeof(reverse), v) = @set reverse(Tuple(x)) = v
 function set(x::AbstractVector, ::typeof(reverse), v)
+    res = similar(x, eltype(v))
+    res .= v
+    reverse!(res)
+    res
+end
+function set(x::AbstractVector, ::typeof(reverse), v::AbstractVector)
     res = similar(x, eltype(v), size(v))
     res .= v
     reverse!(res)

--- a/test/test_functionlenses.jl
+++ b/test/test_functionlenses.jl
@@ -188,6 +188,7 @@ end
     @test set([1, 2], reverse, (3, 4)) == [4, 3]
     @test set((1, 2), reverse, [3, 4]) === (4, 3)
     @test set((a=1, b=2), reverse, [3, 4]) === (a=4, b=3)
+    @test set([1, 2, 3], reverse, [5, 6]) == [6, 5]
 
     C = KeyedArray([1,2,3], x=[:a, :b, :c])
     @test (@set vec(C) = [5,6,7])::KeyedArray == KeyedArray([5,6,7], x=[:a, :b, :c])


### PR DESCRIPTION
Allow `reverse`d objects to change size. E.g. 


```jl
julia> @modify([10,20,30]) do xs
           xs[2:3]
       end
2-element Vector{Int64}:
 20
 30
```

Resolves #212.