### PR TITLE
Use eltype(v) instead of promote_type when replacing all array elements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Accessors"
 uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>", "Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "0.1.43"
+version = "0.1.44"
 
 [deps]
 CompositionsBase = "a33af91c-f02d-484b-be07-31d278c5ca2b"

--- a/src/functionlenses.jl
+++ b/src/functionlenses.jl
@@ -82,11 +82,7 @@ set(obj::Type{<:Dict{K}}, lens::typeof(valtype), ::Type{V}) where {K,V} = Dict{K
 set(obj, ::typeof(size), v::Tuple) = reshape(obj, v)
 
 # set vec(): keep array shape and type, change its values
-function set(x::AbstractArray, ::typeof(vec), v::AbstractVector)
-    res = similar(x, eltype(v))
-    vec(res) .= v
-    res
-end
+set(x::AbstractArray, ::typeof(vec), v::AbstractVector) = _setindex_fresh(x, v, :)
 
 # set reverse(): keep collection type, change its values
 set(::Tuple, ::typeof(reverse), v) = reverse(Tuple(v))
@@ -112,8 +108,11 @@ delete(obj, o::Base.Fix1{typeof(filter)}) = filter(!o.x, obj)
 set(obj, o::typeof(skipmissing), val) = @set obj |> filter(!ismissing, _) = collect(val)
 modify(f, obj, o::typeof(skipmissing)) = @modify(f, obj |> filter(!ismissing, _))
 
-set(obj, ::typeof(sort), val) = @set obj[sortperm(obj)] = val
-modify(f, obj, ::typeof(sort)) = @modify(f, obj[sortperm(obj)])
+set(obj, ::typeof(sort), val) = _setindex_fresh(obj, val, sortperm(obj))
+function modify(f, obj, ::typeof(sort))
+    perm = sortperm(obj)
+    _setindex_fresh(obj, f(obj[perm]), perm)
+end
 
 ################################################################################
 ##### os

--- a/src/setindex.jl
+++ b/src/setindex.jl
@@ -15,11 +15,13 @@ Base.@propagate_inbounds function setindex(xs::AbstractArray, v, I_raw...)
     return ys
 end
 
-Base.@propagate_inbounds function setindex(xs::AbstractArray, v, ::Colon)
+Base.@propagate_inbounds function _setindex_fresh(xs::AbstractArray, v, I...)
     ys = similar(xs, eltype(v))
-    ys[:] = v
+    ys[I...] = v
     return ys
 end
+
+Base.@propagate_inbounds setindex(xs::AbstractArray, v, ::Colon) = _setindex_fresh(xs, v, :)
 
 Base.@propagate_inbounds function setindex(d0::AbstractDict, v, k)
     K = promote_type(keytype(d0), typeof(k))

--- a/src/setindex.jl
+++ b/src/setindex.jl
@@ -15,6 +15,12 @@ Base.@propagate_inbounds function setindex(xs::AbstractArray, v, I_raw...)
     return ys
 end
 
+Base.@propagate_inbounds function setindex(xs::AbstractArray, v, ::Colon)
+    ys = similar(xs, eltype(v))
+    ys[:] = v
+    return ys
+end
+
 Base.@propagate_inbounds function setindex(d0::AbstractDict, v, k)
     K = promote_type(keytype(d0), typeof(k))
     V = promote_type(valtype(d0), typeof(v))

--- a/test/test_setindex.jl
+++ b/test/test_setindex.jl
@@ -40,6 +40,10 @@ end
     @test Accessors.setindex([1, 2, 3], [4, 5, 6], :) ==ₜ [4, 5, 6]
     @test @inferred(Accessors.setindex([1, 2, 3], ["a", "b", "c"], :)) ==ₜ ["a", "b", "c"]
 
+    # sort: replacing all elements with different eltype
+    @test @inferred(set([3, 1, 2], @optic(sort(_)), ["a", "b", "c"])) ==ₜ ["c", "a", "b"]
+    @test @inferred(set([3, 1, 2], @optic(sort(_)), [1.0, 2.0, 3.0])) ==ₜ [3.0, 1.0, 2.0]
+
     d = Dict(:a => 1, :b => 2)
     @test_throws MethodError Base.setindex(d, 10, :a)
     @test Accessors.setindex(d, 10, :a) == Dict(:a=>10, :b=>2)

--- a/test/test_setindex.jl
+++ b/test/test_setindex.jl
@@ -34,6 +34,12 @@ end
     @test Accessors.setindex([1. 2; 3 4], zeros(2), 1, :) ==ₜ [0. 0; 3 4]
     @test Accessors.setindex([[i, j] for i in 1:2, j in 1:2], [im, im], 1, :) ==ₜ Any[[im] [im]; [[2, 1]] [[2, 2]]]
 
+    # Colon: replacing all elements uses eltype(v), not promote_type
+    @test Accessors.setindex([1, 2, 3], ["a", "b", "c"], :) ==ₜ ["a", "b", "c"]
+    @test Accessors.setindex([1, 2, 3], [1.0, 2.0, 3.0], :) ==ₜ [1.0, 2.0, 3.0]
+    @test Accessors.setindex([1, 2, 3], [4, 5, 6], :) ==ₜ [4, 5, 6]
+    @test @inferred(Accessors.setindex([1, 2, 3], ["a", "b", "c"], :)) ==ₜ ["a", "b", "c"]
+
     d = Dict(:a => 1, :b => 2)
     @test_throws MethodError Base.setindex(d, 10, :a)
     @test Accessors.setindex(d, 10, :a) == Dict(:a=>10, :b=>2)


### PR DESCRIPTION
## Summary
- Add `_setindex_fresh` helper that allocates with `eltype(v)` directly (no `promote_type`, no `copy!`) for cases where all elements are being replaced
- Use it for Colon `setindex`, `sort` (set+modify), and `vec`
- Fixes e.g. `@set sort([1,2,3]) = ["a","b","c"]` returning `Vector{Any}` instead of `Vector{String}`

## Test plan
- Added `@inferred` and `==ₜ` tests for Colon and sort with different eltypes
- Full test suite passes