### PR TITLE
drop overwrite=false check

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Accessors"
 uuid = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>", "Jan Weidner <jw3126@gmail.com> and contributors"]
-version = "0.1.44"
+version = "0.1.45"
 
 [deps]
 CompositionsBase = "a33af91c-f02d-484b-be07-31d278c5ca2b"

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -366,7 +366,6 @@ end
 _macro_expression_result(obj, ret; overwrite) =
     if overwrite
         @assert Meta.isexpr(obj, :escape)
-        only(obj.args) isa Symbol || throw(ArgumentError("Rebinding macros can only be used with plain variables as targets. Got expression: $obj"))
         return :($obj = $ret)
     else
         return ret

--- a/src/sugar.jl
+++ b/src/sugar.jl
@@ -366,6 +366,8 @@ end
 _macro_expression_result(obj, ret; overwrite) =
     if overwrite
         @assert Meta.isexpr(obj, :escape)
+        target = only(obj.args)
+        Meta.isexpr(target, :call) && throw(ArgumentError("Rebinding macros cannot use function calls as targets. Got expression: $target"))
         return :($obj = $ret)
     else
         return ret

--- a/test/test_core.jl
+++ b/test/test_core.jl
@@ -153,11 +153,25 @@ end
     @test (@set $(x[2]) + 2 = 100) == 98
     @test (@set first($x, 2) = [10, 20]) == [10, 20, 3]
 
-    @test_throws Exception eval(:(@reset $(x[2]) = 100))
-    @test_throws Exception eval(:(@reset $(x)[2] = 200))
-
     # ensure the object itself didn't change:
     @test x_orig === x == [1, 2, 3]
+
+    x = [1, 2, 3]
+    x_orig = x
+    @reset $(x[2]) = 100
+    @test x === x_orig == [1, 100, 3]
+
+    x = [1, 2, 3]
+    x_orig = x
+    @reset x[2] = 200
+    @test x == [1, 200, 3]
+    @test x_orig == [1, 2, 3]
+
+    target = Ref((nestedprop=1, other=2))
+    target_orig = target
+    @reset $(target[]).nestedprop = 100
+    @test target === target_orig
+    @test target[] === (nestedprop=100, other=2)
 end
 
 


### PR DESCRIPTION
I remember @jw3126 we discussed this at some point when introducing stuff like `@set $(obj.prop).nestedprop = 123`, and leaned towards the conservative side back then: ie, `@reset` refuses to work with this syntax.
Over time, I was reminded of this limitation whenever working with mutable structs – this would often be convenient! And the last straw was recently, when AI also expected this syntax to work not just with @set but @reset as well.
So, I suggest we reconsider – and just drop the conservative check from that branch.